### PR TITLE
Fix signal handling bug

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1105,9 +1105,11 @@ fake_signal(void)
 
 			// Check if a signal was found, and if so handle it
 			for (i = 0; i < LENGTH(signals); i++)
-				if (strncmp(str_sig, signals[i].sig, len_str_sig) == 0 && signals[i].func)
+				if (strcmp(str_sig, signals[i].sig) == 0 && signals[i].func)
+				{
 					signals[i].func(&(arg));
-
+					break;
+				}
 			// A fake signal was sent
 			return 1;
 		}


### PR DESCRIPTION
The strncmp function inside the fake_signal fetching loop has a bug where it calculates the length of the signal incorrectly, and causes functions such as view to be executed along with viewex and viewall, (as it just compares the "view" characters), this can be fixed by changing the strncmp to strcmp so it doesnt take into account the wrongly calculated length.

Also added a break so it stops looping when it finds the appropriate signal